### PR TITLE
fix: helm upgrade에 --force-conflicts 추가로 kubectl-set field manager 충돌 해결

### DIFF
--- a/.github/workflows/deploy-config-server.yaml
+++ b/.github/workflows/deploy-config-server.yaml
@@ -70,6 +70,7 @@ jobs:
             --create-namespace \
             --set image.repository=${{ secrets.DOCKER_USERNAME }}/config-server \
             --set image.tag=$IMAGE_TAG \
-            --set image.pullPolicy=Always
+            --set image.pullPolicy=Always \
+            --force-conflicts
           
           echo "=== Deployment Finished ==="


### PR DESCRIPTION
kubectl set image로 직접 이미지를 바꾸면 .spec.template.spec.containers[config-server].image 필드의 소유권이 kubectl-set으로 등록되어 helm이 같은 필드를 업데이트 못하는 문제가 있어 helm이 소유권을 가져오도록 수정