### PR TITLE
fix: _allocate_next_uid 시스템 계정 uid 충돌 방지

### DIFF
--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1722,13 +1722,20 @@ def get_user(username: str):
         return jsonify({"error": str(e)}), 500
 
 def _allocate_next_uid(lines, min_uid: int = 10000) -> int:
-    """passwd 라인 목록에서 min_uid 이상인 uid 중 최댓값 + 1을 반환."""
-    max_uid = min_uid - 1
-    for line in lines:
-        rec = parse_passwd_line(line)
-        if rec and rec["uid"] >= min_uid:
-            max_uid = max(max_uid, rec["uid"])
-    return max_uid + 1
+    """관리 유저(uid >= min_uid, home=/home/) 최댓값 + 1부터 시작해
+    passwd 전체에서 사용 중이지 않은 uid를 반환한다.
+    시스템 계정이 중간 번호를 점유해도 건너뛰므로 충돌이 없다."""
+    used_uids = {rec["uid"] for line in lines if (rec := parse_passwd_line(line))}
+    managed_uids = {
+        rec["uid"] for line in lines
+        if (rec := parse_passwd_line(line))
+        and rec["uid"] >= min_uid
+        and rec.get("home", "").startswith("/home/")
+    }
+    candidate = max(managed_uids, default=min_uid - 1) + 1
+    while candidate in used_uids:
+        candidate += 1
+    return candidate
 
 
 @accounts_bp.route("/users", methods=["PUT"])


### PR DESCRIPTION
  이전 PR에서 uid/gid 인프라 단독 관리로 전환했으나,                           
  _allocate_next_uid가 passwd의 최대 uid + 1을 반환하는 단순 로직으로, 시스템 계정에 대한 처리가 불명확했음을
  확인.                                                                        
                                                                               
  ## 변경 사항                                                                 
                                                                             
  ### _allocate_next_uid 로직 개선
  - 기존: passwd 전체에서 uid >= 10000 최댓값 + 1 반환
  - 변경: 관리 유저(uid >= 10000, home=/home/) 최댓값 + 1부터 시작해           
    passwd 전체 기준으로 사용 중이지 않은 uid를 탐색해 반환                    
                                                                               
  ### 충돌 시나리오 대응                                                       
  -  시스템 high-uid 계정: home=/home/ 아님 → 관리 max 계산에서
   제외                                                                        
  - 시스템 계정이 중간 번호(예: 10010)를 점유하는 경우: used_uids에 포함되므로
  건너뛰고 10011 반환                                                          
  - 두 케이스 모두 안전하게 처리                                             
                                                                               
  ### 기존 중복 uid 계정 정리                                                                             
                                                          
                                                                               
  ## 테스트       
  - [x] 신규 유저 생성 시 uid 10010 정상 할당 확인                                             
  - [x] 중복 uid 계정 11개 삭제 완료
                                     