### PR TITLE
fix: sudoers 로컬 관리 전환 및 passwd 해싱 서버사이드 처리

### DIFF
--- a/config-server/main.py
+++ b/config-server/main.py
@@ -14,6 +14,8 @@ from flasgger import Swagger
 from dotenv import load_dotenv
 load_dotenv()
 
+import base64
+import crypt
 import logging, sys
 
 from utils import (
@@ -1790,16 +1792,16 @@ def create_user():
           type: object
           required:
             - name
-            - passwd_sha512
+            - passwd_base64
           properties:
             name:
               type: string
               description: 사용자 이름
               example: user2100
-            passwd_sha512:
+            passwd_base64:
               type: string
-              description: SHA-512 해시 패스워드
-              example: "$6$hash..."
+              description: Base64 인코딩된 평문 패스워드
+              example: "cGFzc3dvcmQ="
             gecos:
               type: string
               example: "GPU User"
@@ -1831,7 +1833,7 @@ def create_user():
         description: 서버 오류
     """
     data = request.get_json(force=True)
-    required = ["name", "passwd_sha512"]
+    required = ["name", "passwd_base64"]
     missing = [k for k in required if k not in data]
     if missing:
         return jsonify({"error": f"missing fields: {', '.join(missing)}"}), 400
@@ -1916,11 +1918,14 @@ def create_user():
         f.truncate()
 
     # 3) shadow
+    plaintext_pw = base64.b64decode(data["passwd_base64"]).decode("utf-8")
+    passwd_sha512 = crypt.crypt(plaintext_pw, crypt.mksalt(crypt.METHOD_SHA512))
+
     today_days = int(time.time() // 86400)
     sh_lines = read_shadow_lines()
     shadow_entry = {
         "name": name,
-        "passwd": data["passwd_sha512"],
+        "passwd": passwd_sha512,
         "lastchg": today_days,
         "min": 0,
         "max": 99999,

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -21,7 +21,7 @@ import logging, sys
 from utils import (
     get_db_connection, is_pod_ready, get_existing_pod, generate_pod_name, delete_pod_util,
     LockedFile,get_node_gpu_score,
-    ensure_etc_layout, ensure_sudoers_dir, ensure_sudoers_file,
+    ensure_etc_layout,
     read_passwd_lines, write_passwd_lines,
     read_group_lines, write_group_lines,
     read_shadow_lines, write_shadow_lines,
@@ -90,13 +90,9 @@ app.config.from_mapping({
     "BASE_ETC_DIR": BASE_ETC_DIR,
     "ACCOUNT_NFS_SERVER": os.getenv("NFS_SERVER", os.getenv("NFS_ADDRESS", "")),
     "ACCOUNT_NFS_PATH": os.getenv("NFS_PATH", ""),
-    "SUDO_ALLOWED_COMMANDS": [
-        cmd.strip() for cmd in os.getenv("SUDO_ALLOWED_COMMANDS", "").split(",") if cmd.strip()
-    ],
     "PASSWD_PATH": BASE_ETC_DIR + "/passwd",
     "GROUP_PATH": BASE_ETC_DIR + "/group",
     "SHADOW_PATH": BASE_ETC_DIR + "/shadow",
-    "SUDOERS_DIR": BASE_ETC_DIR + "/sudoers.d",
     "BASH_LOGOUT_PATH": BASE_ETC_DIR + "/bash.bash_logout",
     "BASHRC_PATH": BASE_ETC_DIR + "/bashrc",
 })
@@ -606,21 +602,8 @@ def _resolve_shared_groups(gid_list: List[int], primary_gid: int) -> List[tuple]
     return result
 
 
-def _get_sudo_allowed_commands() -> List[str]:
-    return [cmd for cmd in app.config.get("SUDO_ALLOWED_COMMANDS", []) if cmd]
-
-
-def _build_sudoers_policy(username: str) -> str:
-    allowed_commands = _get_sudo_allowed_commands()
-    if allowed_commands:
-        return f"{username} ALL=(ALL) PASSWD: {', '.join(allowed_commands)}\n"
-    return f"{username} ALL=(ALL) NOPASSWD:ALL\n"
-
-
 def _get_account_file_subpaths() -> List[str]:
-    subpaths = list(app.config["ACCOUNT_FILE_SUBPATHS"])
-    subpaths.append("sudoers.d/{username}")
-    return subpaths
+    return list(app.config["ACCOUNT_FILE_SUBPATHS"])
 
 def build_pod_spec(
     username: str,
@@ -634,10 +617,6 @@ def build_pod_spec(
 
     # subPath mounts require the source files to already exist on the NFS share.
     ensure_etc_layout()
-
-    ensure_sudoers_file(
-        app.config["SUDOERS_DIR"], username, _build_sudoers_policy(username)
-    )
 
     canonical = resolve_k8s_node_name(target_node)
     if not canonical:
@@ -795,9 +774,7 @@ def build_pod_spec(
         # fallback 세팅
         for sub in _get_account_file_subpaths():
             sub_fmt = sub.format(username=username)
-            if sub.startswith("sudoers.d/"):
-                mount_path = f"/etc/sudoers.d/{username}"
-            elif sub == "bash.bash_logout":
+            if sub == "bash.bash_logout":
                 mount_path = f"/home/{username}/.bash_logout"
             elif sub == "bashrc":
                 mount_path = f"/home/{username}/.bashrc"
@@ -829,10 +806,7 @@ def build_pod_spec(
             legacy_etc_mounts = []
             for sub in _get_account_file_subpaths():
                 sub_fmt = sub.format(username=username)
-                if sub.startswith("sudoers.d/"):
-                    mount_path = f"/etc/sudoers.d/{username}"
-                    source_subpath = sub_fmt
-                elif sub == "bash.bash_logout":
+                if sub == "bash.bash_logout":
                     mount_path = f"/home/{username}/.bash_logout"
                     source_subpath = "bash.bash_logout"
                 elif sub == "bashrc":
@@ -1772,7 +1746,6 @@ def create_user():
     - /etc/passwd
     - /etc/shadow
     - /etc/group
-    - /etc/sudoers.d/
 
     ---
     tags:
@@ -1937,17 +1910,11 @@ def create_user():
     sh_lines.append(format_shadow_entry(shadow_entry))
     write_shadow_lines(sh_lines)
 
-    # 4) sudoers
-    s_path = ensure_sudoers_file(
-        app.config["SUDOERS_DIR"], name, _build_sudoers_policy(name)
-    )
-
     return jsonify({
         "status": "created",
         "user": entry,
         "group": {"name": pg_name, "gid": gid},
         "supplementary_groups": added_supp,
-        "sudoers": s_path,
     }), 201
 
 @accounts_bp.route("/users/<username>", methods=["DELETE"])
@@ -1960,7 +1927,6 @@ def delete_user(username: str):
     - /etc/passwd
     - /etc/shadow
     - /etc/group
-    - /etc/sudoers.d/
 
     ---
     tags:
@@ -2014,18 +1980,6 @@ def delete_user(username: str):
             continue
         sh_new.append(sl)
     write_shadow_lines(sh_new)
-
-    # Remove sudoers file if present
-    try:
-        ensure_sudoers_dir()
-        path = os.path.join(app.config["SUDOERS_DIR"], username)
-        if os.path.exists(path):
-            # lock-then-remove pattern
-            with LockedFile(path, "r+") as _:
-                pass
-            os.remove(path)
-    except Exception:
-        pass
 
     # Clean /etc/group: remove user from all member lists; delete any group that had this user
     # (either explicitly in members or implicitly as the primary GID group) if now empty.

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -608,17 +608,16 @@ def _get_sudo_allowed_commands() -> List[str]:
     return [cmd for cmd in app.config.get("SUDO_ALLOWED_COMMANDS", []) if cmd]
 
 
-def _build_sudoers_policy(username: str) -> Optional[str]:
+def _build_sudoers_policy(username: str) -> str:
     allowed_commands = _get_sudo_allowed_commands()
-    if not allowed_commands:
-        return None
-    return f"{username} ALL=(ALL) PASSWD: {', '.join(allowed_commands)}\n"
+    if allowed_commands:
+        return f"{username} ALL=(ALL) PASSWD: {', '.join(allowed_commands)}\n"
+    return f"{username} ALL=(ALL) NOPASSWD:ALL\n"
 
 
 def _get_account_file_subpaths() -> List[str]:
     subpaths = list(app.config["ACCOUNT_FILE_SUBPATHS"])
-    if _get_sudo_allowed_commands():
-        subpaths.append("sudoers.d/{username}")
+    subpaths.append("sudoers.d/{username}")
     return subpaths
 
 def build_pod_spec(
@@ -1929,7 +1928,7 @@ def create_user():
     sh_lines.append(format_shadow_entry(shadow_entry))
     write_shadow_lines(sh_lines)
 
-    # 4) sudoers (optional, password-protected whitelist only)
+    # 4) sudoers
     s_path = None
     sudoers_policy = _build_sudoers_policy(name)
     if sudoers_policy:

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -19,7 +19,7 @@ import logging, sys
 from utils import (
     get_db_connection, is_pod_ready, get_existing_pod, generate_pod_name, delete_pod_util,
     LockedFile,get_node_gpu_score,
-    ensure_etc_layout, ensure_sudoers_dir,
+    ensure_etc_layout, ensure_sudoers_dir, ensure_sudoers_file,
     read_passwd_lines, write_passwd_lines,
     read_group_lines, write_group_lines,
     read_shadow_lines, write_shadow_lines,
@@ -632,6 +632,10 @@ def build_pod_spec(
 
     # subPath mounts require the source files to already exist on the NFS share.
     ensure_etc_layout()
+
+    ensure_sudoers_file(
+        app.config["SUDOERS_DIR"], username, _build_sudoers_policy(username)
+    )
 
     canonical = resolve_k8s_node_name(target_node)
     if not canonical:
@@ -1929,16 +1933,9 @@ def create_user():
     write_shadow_lines(sh_lines)
 
     # 4) sudoers
-    s_path = None
-    sudoers_policy = _build_sudoers_policy(name)
-    if sudoers_policy:
-        ensure_sudoers_dir()
-        s_path = os.path.join(app.config["SUDOERS_DIR"], name)
-        tmp = s_path + ".tmp"
-        with LockedFile(tmp, "w") as f:
-            f.write(sudoers_policy)
-        os.replace(tmp, s_path)
-        os.chmod(s_path, 0o440)
+    s_path = ensure_sudoers_file(
+        app.config["SUDOERS_DIR"], name, _build_sudoers_policy(name)
+    )
 
     return jsonify({
         "status": "created",

--- a/config-server/utils.py
+++ b/config-server/utils.py
@@ -490,8 +490,30 @@ def format_shadow_entry(d: dict) -> str:
     )
 
 
+_VALID_USERNAME_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+
+
 def ensure_sudoers_dir():
     ensure_etc_layout()
+
+
+def ensure_sudoers_file(sudoers_dir: str, username: str, policy: str) -> str:
+    if not _VALID_USERNAME_RE.match(username):
+        raise ValueError(f"invalid username for sudoers: {username!r}")
+
+    ensure_sudoers_dir()
+    target = os.path.join(sudoers_dir, username)
+
+    tmp = target + f".tmp.{os.getpid()}"
+    with LockedFile(target, "a+") as f:
+        f.seek(0, os.SEEK_END)
+        if f.tell() > 0:
+            return target
+        with open(tmp, "w") as tf:
+            tf.write(policy)
+        os.chmod(tmp, 0o440)
+        os.replace(tmp, target)
+    return target
 
 
 def nfs_share_root() -> str:


### PR DESCRIPTION
관련 이슈: #38

## Summary
1. sudoers 파일을 NFS 마운트 대신 컨테이너 로컬 호스트에서 관리하도록 변경
- NFS의 root_squash 도입으로 인해 sudoer는 각 서버 호스트 내부에서 관리
- sudoers 파일 생성 시 트랜잭션 보장 로직 추가
2. passwd 해싱을 클라이언트(SHA-512 전달)에서 서버사이드(base64 평문 → 서버에서 SHA-512 해싱)로 전환


## 배경지식
문제의 본질은 
**sudoers 파일의 소유권과 권한(root:root, 0440)이 NFS 마운트 환경에서 보장되지 않음**
- NFS는 `no_root_squash` 없이는 root 소유 파일의 권한을 유지할 수 없고, 이를 설정하면 보안 리스크가 발생한다. 
- sudoers의 파일 소유권은 꼭 root:root로 해야한다. `-r--r----- 1 root root ...` (https://www.sudo.ws/docs/man/sudoers.man)

또한 passwd 해시를 클라이언트에서 만들어 전달하는 방식은 해싱 알고리즘의 **일관성을 서버가 보장할 수 없는 구조적 문제**가 있었다.

## 수정 부분
1. **sudoers를 NFS 공유에서 제거**: `SUDOERS_DIR`, `SUDO_ALLOWED_COMMANDS` 설정 및 관련 마운트 로직 전부 삭제. sudoers 파일은 로컬 호스트에서 직접 관리하는 방식으로 전환

2. **passwd 해싱 서버사이드 전환**: API 인터페이스를 `passwd_sha512` → `passwd_base64`로 변경. 서버에서 `crypt.crypt()`로 SHA-512 해싱 수행

4. **sudoers 파일 생성 트랜잭션 보장**: `utils.py`에 `ensure_sudoers_file()` 함수 추가 — 파일 잠금 + tmp → rename 패턴으로 원자적 쓰기 보장, 유저네임 검증 포함

5. **`_get_account_file_subpaths()`에서 sudoers 분기 제거**: NFS 서브패스에 sudoers가 포함되지 않도록 단순화

## 예상 결과
- 컨테이너 내에서 sudo 명령이 정상 동작 (sudoers 권한 문제 해소)
- passwd 해싱이 서버에서 일관되게 처리되어 인증 실패 방지
- sudoers 파일 생성 시 race condition이나 부분 쓰기로 인한 손상 방지

## 테스트 계획
- [x] 사용자 생성 API 호출 시 `passwd_base64` 필드로 정상 생성 확인
- [x] 생성된 컨테이너에서 `sudo` 명령 실행 가능 여부 확인
- [ ] 사용자 삭제 시 sudoers 관련 에러 없이 정상 삭제 확인
- [x] 기존 사용자 컨테이너 재시작 시 영향 없음 확인

## 의논 사항
- `passwd_base64`로 평문을 base64 인코딩해서 보내는 현재 방식은 전송 구간 보안(TLS)이 전제되어야 함. 내부 네트워크 전용이므로 현재는 수용 가능하나, 외부 노출 시 재검토 필요