### PR TITLE
[ fix ] 인프라 k8s API 에러코드 구조화 + GPU 노드 선택 시 prometheus 쿼리 수정  

### DIFF
--- a/config-server/README.md
+++ b/config-server/README.md
@@ -102,7 +102,7 @@ ContainerSSH가 사용자별 GPU Pod를 만들고 지우는 데 필요한 Flask 
 8. Pod가 Ready가 되면 `create_nodeport_services()`로 SSH/Jupyter/추가 포트용 NodePort Service를 생성한다.
 9. 성공하면 `{status, node, pod_name, ports}`를 201로 반환한다.
 
-실패 처리도 중요하다. Pod 생성, Ready 대기, Service 생성 중 문제가 생기면 `release_nodeports()`로 DB에 잡아둔 포트를 해제하고, 생성된 Pod가 있으면 삭제를 시도한다. 즉, `create_pod()`는 Pod와 NodePort DB 상태가 어긋나지 않도록 rollback 성격의 정리를 포함한다.
+실패 처리도 중요하다. Pod 생성, Ready 대기, Service 생성 중 문제가 생기면 `release_nodeports()`로 DB에 잡아둔 포트를 해제하고, 생성된 Pod가 있으면 삭제를 시도한다. 즉, `create_pod()`는 Pod와 NodePort DB 상태가 어긋나지 않도록 `progress` 성격의 정리를 포함한다.
 
 ### `build_pod_spec`
 
@@ -144,6 +144,8 @@ ContainerSSH가 사용자별 GPU Pod를 만들고 지우는 데 필요한 Flask 
 
 처리 순서는 NodePort Service 삭제, NodePort DB allocation 해제, Kubernetes Pod 삭제이다. Pod 이름은 `containerssh-`로 시작해야 하며, 이름 형식이 맞지 않으면 400을 반환한다. Pod 이름에서 username을 파싱하지만, 현재 삭제 동작의 핵심 key는 username이 아니라 pod_name이다.
 
+응답의 `progress`는 실제 rollback 수행 결과가 아니라 처리 단계 완료 여부를 담는다. `podDeleteRequested`는 삭제 요청이 K8s에 수락됐는지, `podDeleted`는 watch로 실제 삭제 완료를 확인했는지, `already_absent`는 대상이 원래 없던 경우인지 구분한다. timeout이면 `POD_DELETE_TIMEOUT`으로 응답하고 `podDeleted`는 `false`로 남긴다.
+
 이 함수는 `create_pod()`의 반대 방향 정리 함수이다. 운영 중 수동 삭제가 필요할 때는 Pod만 직접 삭제하기보다 이 API를 통해 Service와 DB allocation까지 같이 정리하는 것이 안전하다.
 
 ### `migrate`와 `_migrate_internal`
@@ -164,7 +166,7 @@ ContainerSSH가 사용자별 GPU Pod를 만들고 지우는 데 필요한 Flask 
 
 이미 PVC가 있으면 Kubernetes patch API로 storage request를 수정해 resize한다. 없으면 새 PVC를 만들고 최대 30초 동안 Bound 상태와 PV 이름을 기다린다. Bound 후 `create_directory_with_permissions(pvc_name, type, name)`로 `/kube_share` 마운트 아래 CSI 경로(`user/<pvc>` 또는 `group-volumes/<pvc>`)의 소유권을 맞춘다. 여러 PVC를 한 요청에서 처리하므로 응답은 항상 `results` 배열 중심이다.
 
-모든 항목이 성공하면 HTTP 200을 반환한다. 요청 자체가 비어 있으면 HTTP 400을 반환하고, batch 처리 결과 중 `error`가 하나라도 있으면 HTTP 500을 반환한다. 실패 항목은 BE가 매핑할 수 있도록 `step`, `error`, `detail`, `rollback`, `name`, `type` 필드를 포함한다. Kubernetes API 예외인 경우 `k8s_status`, `k8s_reason`도 함께 포함한다.
+모든 항목이 성공하면 HTTP 200을 반환한다. 요청 자체가 비어 있으면 HTTP 400을 반환하고, batch 처리 결과 중 `error`가 하나라도 있으면 HTTP 500을 반환한다. 실패 항목은 BE가 매핑할 수 있도록 `step`, `error`, `detail`, `progress`, `name`, `type` 필드를 포함한다. Kubernetes API 예외인 경우 `k8s_status`, `k8s_reason`도 함께 포함한다.
 
 ### `create_user`
 

--- a/config-server/README.md
+++ b/config-server/README.md
@@ -164,6 +164,8 @@ ContainerSSH가 사용자별 GPU Pod를 만들고 지우는 데 필요한 Flask 
 
 이미 PVC가 있으면 Kubernetes patch API로 storage request를 수정해 resize한다. 없으면 새 PVC를 만들고 최대 30초 동안 Bound 상태와 PV 이름을 기다린다. Bound 후 `create_directory_with_permissions(pvc_name, type, name)`로 `/kube_share` 마운트 아래 CSI 경로(`user/<pvc>` 또는 `group-volumes/<pvc>`)의 소유권을 맞춘다. 여러 PVC를 한 요청에서 처리하므로 응답은 항상 `results` 배열 중심이다.
 
+모든 항목이 성공하면 HTTP 200을 반환한다. 요청 자체가 비어 있으면 HTTP 400을 반환하고, batch 처리 결과 중 `error`가 하나라도 있으면 HTTP 500을 반환한다. 실패 항목은 BE가 매핑할 수 있도록 `step`, `error`, `detail`, `rollback`, `name`, `type` 필드를 포함한다. Kubernetes API 예외인 경우 `k8s_status`, `k8s_reason`도 함께 포함한다.
+
 ### `create_user`
 
 `PUT /accounts/users`는 Pod 안에 mount될 Linux 계정 파일을 갱신하는 API이다. 실제 OS의 `/etc/passwd`를 직접 수정하는 것이 아니라, config-server가 관리하는 NFS 계정 파일(`/kube_share/passwd`, `/kube_share/group`, `/kube_share/shadow`, 선택적으로 `/kube_share/sudoers.d/<user>`)을 수정한다.

--- a/config-server/error.py
+++ b/config-server/error.py
@@ -1,9 +1,9 @@
-def infra_error(step, error, detail, rollback=None, **extra):
+def infra_error(step, error, detail, progress=None, rollback=None, **extra):
     body = {
         "step": step,
         "error": error,
         "detail": detail,
-        "rollback": rollback or {},
+        "progress": progress if progress is not None else (rollback or {}),
     }
     body.update({key: value for key, value in extra.items() if value is not None})
     return body

--- a/config-server/error.py
+++ b/config-server/error.py
@@ -1,0 +1,17 @@
+def infra_error(step, error, detail, rollback=None, **extra):
+    body = {
+        "step": step,
+        "error": error,
+        "detail": detail,
+        "rollback": rollback or {},
+    }
+    body.update({key: value for key, value in extra.items() if value is not None})
+    return body
+
+
+def k8s_error_fields(exc):
+    return {
+        "k8s_status": exc.status,
+        "k8s_reason": exc.reason,
+        "k8s_body": exc.body,
+    }

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1728,23 +1728,6 @@ def create_or_resize_pvc():
     results = []
     namespace = app.config["NAMESPACE"]
 
-    def pvc_error(step, error, detail, name=None, pvc_type=None, k8s_status=None, k8s_reason=None):
-        result = {
-            "step": step,
-            "error": error,
-            "detail": detail,
-            "rollback": {},
-        }
-        if name is not None:
-            result["name"] = name
-        if pvc_type is not None:
-            result["type"] = pvc_type
-        if k8s_status is not None:
-            result["k8s_status"] = k8s_status
-        if k8s_reason is not None:
-            result["k8s_reason"] = k8s_reason
-        return result
-
     try:
         try:
             k8s_config.load_incluster_config()
@@ -1763,23 +1746,25 @@ def create_or_resize_pvc():
 
             if not name or not storage_raw:
                 app.logger.error(f"Missing required fields for {pvc_config}")
-                results.append(pvc_error(
+                results.append(infra_error(
                     "VALIDATE_REQUEST",
                     "INVALID_PVC_REQUEST",
                     f"name and storage required for {pvc_config}",
-                    name,
-                    pvc_type,
+                    name=name,
+                    type=pvc_type,
+                    rollback={},
                 ))
                 continue
 
             if pvc_type not in ["user", "group"]:
                 app.logger.error(f"Invalid PVC type '{pvc_type}' for {name}")
-                results.append(pvc_error(
+                results.append(infra_error(
                     "VALIDATE_REQUEST",
                     "INVALID_PVC_REQUEST",
                     f"type must be 'user' or 'group' for {name}",
-                    name,
-                    pvc_type,
+                    name=name,
+                    type=pvc_type,
+                    rollback={},
                 ))
                 continue
 
@@ -1825,14 +1810,14 @@ def create_or_resize_pvc():
                     results.append({"status": "resized", "name": name, "type": pvc_type, "pvc_name": pvc_name, "storage": storage})
                 except client.exceptions.ApiException as e:
                     if e.status != 404:
-                        results.append(pvc_error(
+                        results.append(infra_error(
                             "RESIZE_PVC",
                             "PVC_RESIZE_FAILED",
                             f"Kubernetes API error for {name}: {e.body}",
-                            name,
-                            pvc_type,
-                            e.status,
-                            e.reason,
+                            name=name,
+                            type=pvc_type,
+                            rollback={},
+                            **k8s_error_fields(e),
                         ))
                         continue
 
@@ -1853,14 +1838,14 @@ def create_or_resize_pvc():
                     try:
                         core_v1.create_namespaced_persistent_volume_claim(namespace, pvc_body)
                     except client.exceptions.ApiException as e:
-                        results.append(pvc_error(
+                        results.append(infra_error(
                             "CREATE_PVC",
                             "PVC_CREATE_FAILED",
                             e.body,
-                            name,
-                            pvc_type,
-                            e.status,
-                            e.reason,
+                            name=name,
+                            type=pvc_type,
+                            rollback={},
+                            **k8s_error_fields(e),
                         ))
                         continue
                     app.logger.info(f"Created PVC: {pvc_name}")
@@ -1899,12 +1884,13 @@ def create_or_resize_pvc():
                     results.append({"status": "created", "name": name, "type": pvc_type, "pvc_name": pvc_name, "storage": storage})
 
             except Exception as e:
-                results.append(pvc_error(
+                results.append(infra_error(
                     "CREATE_PVC",
                     "PVC_CREATE_FAILED",
                     f"Failed to process {name}: {str(e)}",
-                    name,
-                    pvc_type,
+                    name=name,
+                    type=pvc_type,
+                    rollback={},
                 ))
 
         has_error = any("error" in result for result in results)

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1336,6 +1336,15 @@ def delete_pod():
             v1.delete_namespaced_pod(pod_name, ns)
             rollback["podDeleted"] = True
         except client.exceptions.ApiException as e:
+            if e.status == 404:
+                rollback["podDeleted"] = True
+                app.logger.info("[DELETE POD] pod already absent: %s", pod_name)
+                return jsonify({
+                    "status": "deleted",
+                    "pod_name": pod_name,
+                    "already_absent": True,
+                    "rollback": rollback,
+                }), 200
             app.logger.exception("[DELETE POD] pod deletion failed")
             return jsonify(infra_error(
                 "DELETE_POD",

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -151,9 +151,9 @@ def wait_for_pod_deleted(v1, pod_name, namespace, timeout_sec=60):
 
 
 class PodSpecBuildError(Exception):
-    def __init__(self, message, rollback=None):
+    def __init__(self, message, progress=None):
         super().__init__(message)
-        self.rollback = rollback or {}
+        self.progress = progress or {}
 
 # ////////////////////// 포트 할당 //////////////////////
 
@@ -631,7 +631,7 @@ def create_pod():
                 "BUILD_POD_SPEC",
                 "POD_SPEC_BUILD_FAILED",
                 str(e),
-                rollback=e.rollback,
+                progress=e.progress,
                 pod_name=pod_name,
             )), 500
         except ValueError as e:
@@ -1196,7 +1196,7 @@ def build_pod_spec(
                 pod_name,
                 exc_info=True,
             )
-        raise PodSpecBuildError(str(e), rollback=rollback) from e
+        raise PodSpecBuildError(str(e), progress=rollback) from e
 
 # //////////////////////// Pod 삭제 //////////////////////
 
@@ -1347,7 +1347,7 @@ def delete_pod():
                     "status": "deleted",
                     "pod_name": pod_name,
                     "already_absent": True,
-                    "rollback": rollback,
+                    "progress": rollback,
                 }), 200
             app.logger.exception("[DELETE POD] pod deletion failed")
             return jsonify(infra_error(
@@ -1407,7 +1407,7 @@ def delete_pod():
         return jsonify({
             "status": "deleted",
             "pod_name": pod_name,
-            "rollback": rollback,
+            "progress": rollback,
         }), 200
 
     except Exception as e:
@@ -1704,7 +1704,7 @@ def create_or_resize_pvc():
                 "step": "VALIDATE_REQUEST",
                 "error": "INVALID_PVC_REQUEST",
                 "detail": "pvcs list is required",
-                "rollback": {},
+                "progress": {},
             }],
         }), 400
 
@@ -1881,14 +1881,14 @@ def create_or_resize_pvc():
         return jsonify({"results": results}), status
 
     except Exception as e:
-        return jsonify({
+                return jsonify({
             "error": "PVC_OPERATION_FAILED",
             "detail": str(e),
             "results": [{
                 "step": "CREATE_PVC",
                 "error": "PVC_OPERATION_FAILED",
                 "detail": str(e),
-                "rollback": {},
+                "progress": {},
             }],
         }), 500
 

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -127,6 +127,25 @@ def load_k8s():
     except:
         k8s_config.load_kube_config()
 
+
+def infra_error(step, error, detail, rollback=None, **extra):
+    body = {
+        "step": step,
+        "error": error,
+        "detail": detail,
+        "rollback": rollback or {},
+    }
+    body.update({key: value for key, value in extra.items() if value is not None})
+    return body
+
+
+def k8s_error_fields(exc):
+    return {
+        "k8s_status": exc.status,
+        "k8s_reason": exc.reason,
+        "k8s_body": exc.body,
+    }
+
 # ////////////////////// 포트 할당 //////////////////////
 
 # reconcile 쓰로틀: 마지막 실행 시각(Unix timestamp). 앱 시작 시 0으로 초기화.

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -146,6 +146,12 @@ def k8s_error_fields(exc):
         "k8s_body": exc.body,
     }
 
+
+class PodSpecBuildError(Exception):
+    def __init__(self, message, rollback=None):
+        super().__init__(message)
+        self.rollback = rollback or {}
+
 # ////////////////////// 포트 할당 //////////////////////
 
 # reconcile 쓰로틀: 마지막 실행 시각(Unix timestamp). 앱 시작 시 0으로 초기화.
@@ -415,24 +421,89 @@ def create_pod():
 
     if not username:
         app.logger.warning("[CREATE POD] username missing in request")
-        return jsonify({"error": "username required"}), 400
+        return jsonify(infra_error(
+            "VALIDATE_REQUEST",
+            "INVALID_CREATE_POD_REQUEST",
+            "username required",
+        )), 400
 
     ns = app.config["NAMESPACE"]
+
+    def cleanup_create_failure(pod_name, v1=None, delete_services=False):
+        rollback = {
+            "nodeportsReleased": False,
+            "podDeleted": False,
+            "servicesDeleted": False,
+        }
+
+        if delete_services:
+            try:
+                delete_nodeport_services(pod_name, ns)
+                rollback["servicesDeleted"] = True
+            except Exception:
+                app.logger.warning("[CREATE POD] cleanup service deletion failed", exc_info=True)
+
+        try:
+            release_nodeports(pod_name)
+            rollback["nodeportsReleased"] = True
+        except Exception:
+            app.logger.warning("[CREATE POD] cleanup nodeport release failed", exc_info=True)
+
+        if v1 is not None:
+            try:
+                v1.delete_namespaced_pod(pod_name, ns)
+                rollback["podDeleted"] = True
+            except client.exceptions.ApiException as e:
+                if e.status == 404:
+                    rollback["podDeleted"] = True
+                else:
+                    app.logger.warning("[CREATE POD] cleanup pod deletion failed", exc_info=True)
+            except Exception:
+                app.logger.warning("[CREATE POD] cleanup pod deletion failed", exc_info=True)
+
+        return rollback
 
     try:
         # WAS 조회
         was_url = app.config["WAS_URL_TEMPLATE"].format(username=username)
         app.logger.info(f"[CREATE POD] requesting user config from WAS: {was_url}")
 
-        resp = requests.get(was_url, timeout=app.config["HTTP_TIMEOUT_SEC"])
-        user_info = resp.json()
+        try:
+            resp = requests.get(was_url, timeout=app.config["HTTP_TIMEOUT_SEC"])
+            user_info = resp.json()
+        except requests.RequestException as e:
+            app.logger.exception("[CREATE POD] WAS request failed")
+            return jsonify(infra_error(
+                "FETCH_USER_CONFIG",
+                "USER_CONFIG_FETCH_FAILED",
+                str(e),
+            )), 502
+        except ValueError as e:
+            app.logger.exception("[CREATE POD] invalid WAS response")
+            return jsonify(infra_error(
+                "FETCH_USER_CONFIG",
+                "USER_CONFIG_INVALID_RESPONSE",
+                str(e),
+                was_status=resp.status_code if "resp" in locals() else None,
+            )), 502
+
         # WAS가 HTTP 200 + body {"status": 404} 형태로 유저 없음을 알리는 경우 처리
         if user_info.get("status") == 404 or resp.status_code == 404:
             app.logger.warning(f"[CREATE POD] user {username!r} not found in WAS")
-            return jsonify({"error": f"user {username!r} not found in WAS"}), 404
+            return jsonify(infra_error(
+                "FETCH_USER_CONFIG",
+                "USER_CONFIG_NOT_FOUND",
+                f"user {username!r} not found in WAS",
+                was_status=resp.status_code,
+            )), 404
         if resp.status_code >= 400:
             app.logger.error(f"[CREATE POD] WAS returned {resp.status_code}")
-            return jsonify({"error": f"WAS returned {resp.status_code} for user {username!r}"}), 502
+            return jsonify(infra_error(
+                "FETCH_USER_CONFIG",
+                "USER_CONFIG_FETCH_FAILED",
+                f"WAS returned {resp.status_code} for user {username!r}",
+                was_status=resp.status_code,
+            )), 502
 
         app.logger.debug(f"[CREATE POD] user_info received: {user_info}")
 
@@ -440,15 +511,46 @@ def create_pod():
         app.logger.info(f"[CREATE POD] generated pod_name={pod_name}")
 
         # pod_name 중복 확인
-        load_k8s()
-        v1 = client.CoreV1Api()
+        try:
+            load_k8s()
+            v1 = client.CoreV1Api()
+        except Exception as e:
+            app.logger.exception("[CREATE POD] k8s client setup failed")
+            return jsonify(infra_error(
+                "CHECK_EXISTING_POD",
+                "K8S_CLIENT_SETUP_FAILED",
+                str(e),
+                pod_name=pod_name,
+            )), 500
 
         try:
             v1.read_namespaced_pod(pod_name, ns)
             app.logger.warning(f"[CREATE POD] pod already exists: {pod_name}")
-            return jsonify({"error": "pod already exists"}), 409
-        except:
+            return jsonify(infra_error(
+                "CHECK_EXISTING_POD",
+                "POD_ALREADY_EXISTS",
+                "pod already exists",
+                pod_name=pod_name,
+            )), 409
+        except client.exceptions.ApiException as e:
+            if e.status != 404:
+                app.logger.exception("[CREATE POD] pod existence check failed")
+                return jsonify(infra_error(
+                    "CHECK_EXISTING_POD",
+                    "POD_CHECK_FAILED",
+                    e.body,
+                    pod_name=pod_name,
+                    **k8s_error_fields(e),
+                )), 500
             app.logger.debug("[CREATE POD] pod does not exist yet")
+        except Exception as e:
+            app.logger.exception("[CREATE POD] pod existence check failed")
+            return jsonify(infra_error(
+                "CHECK_EXISTING_POD",
+                "POD_CHECK_FAILED",
+                str(e),
+                pod_name=pod_name,
+            )), 500
 
         # Prometheus 기반 노드 선택
         gpu_nodes = user_info.get("gpu_nodes", [])
@@ -461,8 +563,24 @@ def create_pod():
         # WAS가 gpu_nodes를 반환하지 않으면 k8s Ready 워커 노드 전체로 폴백
         if not node_list:
             app.logger.warning("[CREATE POD] gpu_nodes missing from WAS — falling back to all ready worker nodes")
-            load_k8s()
-            _all_nodes = client.CoreV1Api().list_node().items
+            try:
+                load_k8s()
+                _all_nodes = client.CoreV1Api().list_node().items
+            except client.exceptions.ApiException as e:
+                app.logger.exception("[CREATE POD] fallback node list failed")
+                return jsonify(infra_error(
+                    "LIST_NODES",
+                    "NODE_LIST_FAILED",
+                    e.body,
+                    **k8s_error_fields(e),
+                )), 500
+            except Exception as e:
+                app.logger.exception("[CREATE POD] fallback node list failed")
+                return jsonify(infra_error(
+                    "LIST_NODES",
+                    "NODE_LIST_FAILED",
+                    str(e),
+                )), 500
             node_list = [
                 n.metadata.name
                 for n in _all_nodes
@@ -475,11 +593,20 @@ def create_pod():
 
         app.logger.info(f"[CREATE POD] candidate nodes: {node_list}")
 
-        best_node = select_best_node_from_prometheus(
-            node_list,
-            app.config["PROM_URL"],
-            app.config["HTTP_TIMEOUT_SEC"]
-        )
+        try:
+            best_node = select_best_node_from_prometheus(
+                node_list,
+                app.config["PROM_URL"],
+                app.config["HTTP_TIMEOUT_SEC"]
+            )
+        except Exception as e:
+            app.logger.exception("[CREATE POD] node selection failed")
+            return jsonify(infra_error(
+                "SELECT_NODE",
+                "NODE_SELECTION_FAILED",
+                str(e),
+                pod_name=pod_name,
+            )), 500
         app.logger.info(f"[CREATE POD] selected best node: {best_node}")
 
         # Pod spec 생성
@@ -496,30 +623,82 @@ def create_pod():
                 best_node,
                 pod_name
             )
+        except PodSpecBuildError as e:
+            return jsonify(infra_error(
+                "BUILD_POD_SPEC",
+                "POD_SPEC_BUILD_FAILED",
+                str(e),
+                rollback=e.rollback,
+                pod_name=pod_name,
+            )), 500
         except ValueError as e:
-            return jsonify({"error": str(e)}), 400
+            return jsonify(infra_error(
+                "BUILD_POD_SPEC",
+                "POD_SPEC_BUILD_FAILED",
+                str(e),
+                rollback={"nodeportsReleased": False},
+                pod_name=pod_name,
+            )), 400
+        except Exception as e:
+            app.logger.exception("[CREATE POD] pod spec build failed")
+            return jsonify(infra_error(
+                "BUILD_POD_SPEC",
+                "POD_SPEC_BUILD_FAILED",
+                str(e),
+                rollback={"nodeportsReleased": False},
+                pod_name=pod_name,
+            )), 500
         app.logger.debug(f"[CREATE POD] allocated ports: {allocated_ports}")
 
         pod_spec = spec_wrapper["config"]["kubernetes"]["pod"]
         app.logger.info("[CREATE POD] pod spec built")
 
-        load_k8s()
-        v1 = client.CoreV1Api()
-
-        # 실제 Pod 생성
         try:
-            app.logger.info(f"[CREATE POD] creating pod in namespace={ns}")
+            load_k8s()
+            v1 = client.CoreV1Api()
+        except Exception as e:
+            app.logger.exception("[CREATE POD] k8s client setup failed")
+            rollback = cleanup_create_failure(pod_name)
+            return jsonify(infra_error(
+                "CREATE_POD",
+                "K8S_CLIENT_SETUP_FAILED",
+                str(e),
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
 
-            # 1. Pod 생성
+        app.logger.info(f"[CREATE POD] creating pod in namespace={ns}")
+        try:
             v1.create_namespaced_pod(
                 namespace=ns,
                 body=pod_spec
             )
+        except client.exceptions.ApiException as e:
+            app.logger.exception("[CREATE POD] pod creation failed")
+            rollback = cleanup_create_failure(pod_name, v1)
+            return jsonify(infra_error(
+                "CREATE_POD",
+                "POD_CREATE_FAILED",
+                e.body,
+                rollback=rollback,
+                pod_name=pod_name,
+                **k8s_error_fields(e),
+            )), 500
+        except Exception as e:
+            app.logger.exception("[CREATE POD] pod creation failed")
+            rollback = cleanup_create_failure(pod_name, v1)
+            return jsonify(infra_error(
+                "CREATE_POD",
+                "POD_CREATE_FAILED",
+                str(e),
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
 
-            app.logger.info("[CREATE POD] pod creation request sent")
+        app.logger.info("[CREATE POD] pod creation request sent")
 
-            # 2. Ready 대기
-            app.logger.info("[CREATE POD] waiting for pod to become Ready")
+        app.logger.info("[CREATE POD] waiting for pod to become Ready")
+        try:
             for i in range(60):
                 pod = v1.read_namespaced_pod(pod_name, ns)
                 if is_pod_ready(pod):
@@ -529,25 +708,62 @@ def create_pod():
             else:
                 app.logger.error("[CREATE POD] pod failed to become ready")
                 app.logger.info(f"[CREATE POD] deleting failed pod: {pod_name}")
-                release_nodeports(pod_name)
-                v1.delete_namespaced_pod(pod_name, ns)
-                return jsonify({"error": "pod failed to start"}), 500
-
-            # 3. Pod 성공 후 Service 생성
-            app.logger.info("[CREATE POD] creating NodePort services")
-            create_nodeport_services(username, ns, pod_name, allocated_ports)
-
-            app.logger.info("[CREATE POD] services created successfully")
-
+                rollback = cleanup_create_failure(pod_name, v1)
+                return jsonify(infra_error(
+                    "WAIT_POD_READY",
+                    "POD_READY_TIMEOUT",
+                    "pod failed to start",
+                    rollback=rollback,
+                    pod_name=pod_name,
+                )), 500
+        except client.exceptions.ApiException as e:
+            app.logger.exception("[CREATE POD] pod ready check failed")
+            rollback = cleanup_create_failure(pod_name, v1)
+            return jsonify(infra_error(
+                "WAIT_POD_READY",
+                "POD_READY_CHECK_FAILED",
+                e.body,
+                rollback=rollback,
+                pod_name=pod_name,
+                **k8s_error_fields(e),
+            )), 500
         except Exception as e:
-            app.logger.error(f"[CREATE POD] pod creation failed: {str(e)}")
-            release_nodeports(pod_name)
-            try:
-                v1.delete_namespaced_pod(pod_name, ns)
-                app.logger.warning("[CREATE POD] failed pod deleted")
-            except:
-                app.logger.warning("[CREATE POD] cleanup pod deletion failed")
-            raise
+            app.logger.exception("[CREATE POD] pod ready check failed")
+            rollback = cleanup_create_failure(pod_name, v1)
+            return jsonify(infra_error(
+                "WAIT_POD_READY",
+                "POD_READY_CHECK_FAILED",
+                str(e),
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
+
+        app.logger.info("[CREATE POD] creating NodePort services")
+        try:
+            create_nodeport_services(username, ns, pod_name, allocated_ports)
+        except client.exceptions.ApiException as e:
+            app.logger.exception("[CREATE POD] service creation failed")
+            rollback = cleanup_create_failure(pod_name, v1, delete_services=True)
+            return jsonify(infra_error(
+                "CREATE_NODEPORT_SERVICE",
+                "NODEPORT_SERVICE_CREATE_FAILED",
+                e.body,
+                rollback=rollback,
+                pod_name=pod_name,
+                **k8s_error_fields(e),
+            )), 500
+        except Exception as e:
+            app.logger.exception("[CREATE POD] service creation failed")
+            rollback = cleanup_create_failure(pod_name, v1, delete_services=True)
+            return jsonify(infra_error(
+                "CREATE_NODEPORT_SERVICE",
+                "NODEPORT_SERVICE_CREATE_FAILED",
+                str(e),
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
+
+        app.logger.info("[CREATE POD] services created successfully")
 
         app.logger.info(f"[CREATE POD] success - pod={pod_name}, node={best_node}")
 
@@ -560,7 +776,11 @@ def create_pod():
 
     except Exception as e:
         app.logger.exception("[CREATE POD] unexpected error")
-        return jsonify({"error": str(e)}), 500
+        return jsonify(infra_error(
+            "CREATE_POD",
+            "CREATE_POD_FAILED",
+            str(e),
+        )), 500
 
 
 def _normalize_gid_list(raw_gid) -> List[int]:
@@ -958,13 +1178,22 @@ def build_pod_spec(
                     }
         app.logger.info(f"[POD SPEC] complete pod_name={pod_name}")
         return spec, allocated_ports
-    except Exception:
+    except Exception as e:
         app.logger.warning(
             "[POD SPEC] failed after nodeport allocation; releasing rows pod=%s",
             pod_name,
         )
-        release_nodeports(pod_name)
-        raise
+        rollback = {"nodeportsReleased": False}
+        try:
+            release_nodeports(pod_name)
+            rollback["nodeportsReleased"] = True
+        except Exception:
+            app.logger.warning(
+                "[POD SPEC] nodeport release failed during rollback pod=%s",
+                pod_name,
+                exc_info=True,
+            )
+        raise PodSpecBuildError(str(e), rollback=rollback) from e
 
 # //////////////////////// Pod 삭제 //////////////////////
 

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1311,10 +1311,36 @@ def create_or_resize_pvc():
         }]
     
     if not pvcs:
-        return jsonify({"results": [{"error": "pvcs list is required"}]}), 400
+        return jsonify({
+            "error": "INVALID_PVC_REQUEST",
+            "detail": "pvcs list is required",
+            "results": [{
+                "step": "VALIDATE_REQUEST",
+                "error": "INVALID_PVC_REQUEST",
+                "detail": "pvcs list is required",
+                "rollback": {},
+            }],
+        }), 400
 
     results = []
     namespace = app.config["NAMESPACE"]
+
+    def pvc_error(step, error, detail, name=None, pvc_type=None, k8s_status=None, k8s_reason=None):
+        result = {
+            "step": step,
+            "error": error,
+            "detail": detail,
+            "rollback": {},
+        }
+        if name is not None:
+            result["name"] = name
+        if pvc_type is not None:
+            result["type"] = pvc_type
+        if k8s_status is not None:
+            result["k8s_status"] = k8s_status
+        if k8s_reason is not None:
+            result["k8s_reason"] = k8s_reason
+        return result
 
     try:
         try:
@@ -1334,12 +1360,24 @@ def create_or_resize_pvc():
 
             if not name or not storage_raw:
                 app.logger.error(f"Missing required fields for {pvc_config}")
-                results.append({"error": f"name and storage required for {pvc_config}"})
+                results.append(pvc_error(
+                    "VALIDATE_REQUEST",
+                    "INVALID_PVC_REQUEST",
+                    f"name and storage required for {pvc_config}",
+                    name,
+                    pvc_type,
+                ))
                 continue
 
             if pvc_type not in ["user", "group"]:
                 app.logger.error(f"Invalid PVC type '{pvc_type}' for {name}")
-                results.append({"error": f"type must be 'user' or 'group' for {name}"})
+                results.append(pvc_error(
+                    "VALIDATE_REQUEST",
+                    "INVALID_PVC_REQUEST",
+                    f"type must be 'user' or 'group' for {name}",
+                    name,
+                    pvc_type,
+                ))
                 continue
 
             storage = f"{storage_raw}Gi"
@@ -1384,7 +1422,15 @@ def create_or_resize_pvc():
                     results.append({"status": "resized", "name": name, "type": pvc_type, "pvc_name": pvc_name, "storage": storage})
                 except client.exceptions.ApiException as e:
                     if e.status != 404:
-                        results.append({"error": f"Kubernetes API error for {name}: {e.body}"})
+                        results.append(pvc_error(
+                            "RESIZE_PVC",
+                            "PVC_RESIZE_FAILED",
+                            f"Kubernetes API error for {name}: {e.body}",
+                            name,
+                            pvc_type,
+                            e.status,
+                            e.reason,
+                        ))
                         continue
 
                     # PVC doesn't exist → create
@@ -1401,7 +1447,19 @@ def create_or_resize_pvc():
                             storage_class_name=storage_class
                         )
                     )
-                    core_v1.create_namespaced_persistent_volume_claim(namespace, pvc_body)
+                    try:
+                        core_v1.create_namespaced_persistent_volume_claim(namespace, pvc_body)
+                    except client.exceptions.ApiException as e:
+                        results.append(pvc_error(
+                            "CREATE_PVC",
+                            "PVC_CREATE_FAILED",
+                            e.body,
+                            name,
+                            pvc_type,
+                            e.status,
+                            e.reason,
+                        ))
+                        continue
                     app.logger.info(f"Created PVC: {pvc_name}")
 
                     # Wait for PVC to be bound and get the actual PV name
@@ -1438,12 +1496,29 @@ def create_or_resize_pvc():
                     results.append({"status": "created", "name": name, "type": pvc_type, "pvc_name": pvc_name, "storage": storage})
 
             except Exception as e:
-                results.append({"error": f"Failed to process {name}: {str(e)}"})
+                results.append(pvc_error(
+                    "CREATE_PVC",
+                    "PVC_CREATE_FAILED",
+                    f"Failed to process {name}: {str(e)}",
+                    name,
+                    pvc_type,
+                ))
 
-        return jsonify({"results": results})
+        has_error = any("error" in result for result in results)
+        status = 500 if has_error else 200
+        return jsonify({"results": results}), status
 
     except Exception as e:
-        return jsonify({"results": [{"error": str(e)}]}), 500
+        return jsonify({
+            "error": "PVC_OPERATION_FAILED",
+            "detail": str(e),
+            "results": [{
+                "step": "CREATE_PVC",
+                "error": "PVC_OPERATION_FAILED",
+                "detail": str(e),
+                "rollback": {},
+            }],
+        }), 500
 
 
 

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -3,7 +3,7 @@ import fcntl
 import re
 import time
 from typing import List, Optional
-from kubernetes import client, config as k8s_config
+from kubernetes import client, config as k8s_config, watch
 import pymysql
 import os
 import requests
@@ -145,6 +145,26 @@ def k8s_error_fields(exc):
         "k8s_reason": exc.reason,
         "k8s_body": exc.body,
     }
+
+
+def wait_for_pod_deleted(v1, pod_name, namespace, timeout_sec=60):
+    """
+    delete_namespaced_pod() 이후 실제 파드 삭제 완료를 watch 이벤트로 확인한다.
+    """
+    w = watch.Watch()
+    field_selector = f"metadata.name={pod_name}"
+    try:
+        for event in w.stream(
+            v1.list_namespaced_pod,
+            namespace=namespace,
+            field_selector=field_selector,
+            timeout_seconds=timeout_sec,
+        ):
+            if event.get("type") == "DELETED":
+                return True
+        return False
+    finally:
+        w.stop()
 
 
 class PodSpecBuildError(Exception):
@@ -1262,6 +1282,7 @@ def delete_pod():
     rollback = {
         "servicesDeleted": False,
         "nodeportsReleased": False,
+        "podDeleteRequested": False,
         "podDeleted": False,
     }
 
@@ -1334,7 +1355,7 @@ def delete_pod():
 
         try:
             v1.delete_namespaced_pod(pod_name, ns)
-            rollback["podDeleted"] = True
+            rollback["podDeleteRequested"] = True
         except client.exceptions.ApiException as e:
             if e.status == 404:
                 rollback["podDeleted"] = True
@@ -1363,9 +1384,48 @@ def delete_pod():
                 rollback=rollback,
                 pod_name=pod_name,
             )), 500
+
+        app.logger.info("[DELETE POD] waiting for pod deletion to complete")
+        try:
+            deleted = wait_for_pod_deleted(v1, pod_name, ns, timeout_sec=60)
+        except client.exceptions.ApiException as e:
+            app.logger.exception("[DELETE POD] deletion polling failed")
+            return jsonify(infra_error(
+                "DELETE_POD",
+                "POD_DELETE_FAILED",
+                e.body,
+                rollback=rollback,
+                pod_name=pod_name,
+                **k8s_error_fields(e),
+            )), 500
+        except Exception as e:
+            app.logger.exception("[DELETE POD] deletion polling failed")
+            return jsonify(infra_error(
+                "DELETE_POD",
+                "POD_DELETE_FAILED",
+                str(e),
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
+
+        if not deleted:
+            app.logger.warning("[DELETE POD] pod deletion timed out: %s", pod_name)
+            return jsonify(infra_error(
+                "DELETE_POD",
+                "POD_DELETE_TIMEOUT",
+                "pod deletion did not complete within timeout",
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
+
+        rollback["podDeleted"] = True
         app.logger.info(f"[DELETE POD] pod deleted successfully: {pod_name}")
 
-        return jsonify({"status": "deleted"})
+        return jsonify({
+            "status": "deleted",
+            "pod_name": pod_name,
+            "rollback": rollback,
+        }), 200
 
     except Exception as e:
         app.logger.exception("[DELETE POD] deletion failed")

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1252,35 +1252,121 @@ def delete_pod():
 
     if not pod_name:
         app.logger.warning("[DELETE POD] pod_name missing")
-        return jsonify({"error": "pod_name required"}), 400
+        return jsonify(infra_error(
+            "VALIDATE_REQUEST",
+            "INVALID_DELETE_POD_REQUEST",
+            "pod_name required",
+        )), 400
 
     ns = app.config["NAMESPACE"]
+    rollback = {
+        "servicesDeleted": False,
+        "nodeportsReleased": False,
+        "podDeleted": False,
+    }
 
     try:
         if not pod_name.startswith("ailab-"):
             app.logger.warning(f"[DELETE POD] invalid pod_name format: {pod_name}")
-            return jsonify({"error": "invalid pod_name"}), 400
+            return jsonify(infra_error(
+                "VALIDATE_REQUEST",
+                "INVALID_POD_NAME",
+                "invalid pod_name",
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 400
 
         rest = pod_name[len("ailab-"):]
         username = rest.rsplit("-", 1)[0]
 
         app.logger.info(f"[DELETE POD] parsed username={username}")
         app.logger.info("[DELETE POD] deleting NodePort services")
-        delete_nodeport_services(pod_name, ns)
+        try:
+            delete_nodeport_services(pod_name, ns)
+            rollback["servicesDeleted"] = True
+        except client.exceptions.ApiException as e:
+            app.logger.exception("[DELETE POD] service deletion failed")
+            return jsonify(infra_error(
+                "DELETE_NODEPORT_SERVICE",
+                "NODEPORT_SERVICE_DELETE_FAILED",
+                e.body,
+                rollback=rollback,
+                pod_name=pod_name,
+                **k8s_error_fields(e),
+            )), 500
+        except Exception as e:
+            app.logger.exception("[DELETE POD] service deletion failed")
+            return jsonify(infra_error(
+                "DELETE_NODEPORT_SERVICE",
+                "NODEPORT_SERVICE_DELETE_FAILED",
+                str(e),
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
+
         app.logger.info("[DELETE POD] releasing NodePort allocations")
-        release_nodeports(pod_name)
+        try:
+            release_nodeports(pod_name)
+            rollback["nodeportsReleased"] = True
+        except Exception as e:
+            app.logger.exception("[DELETE POD] nodeport release failed")
+            return jsonify(infra_error(
+                "RELEASE_NODEPORT",
+                "NODEPORT_RELEASE_FAILED",
+                str(e),
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
 
         app.logger.info(f"[DELETE POD] deleting pod from namespace={ns}")
-        load_k8s()
-        v1 = client.CoreV1Api()
-        v1.delete_namespaced_pod(pod_name, ns)
+        try:
+            load_k8s()
+            v1 = client.CoreV1Api()
+        except Exception as e:
+            app.logger.exception("[DELETE POD] k8s client setup failed")
+            return jsonify(infra_error(
+                "DELETE_POD",
+                "K8S_CLIENT_SETUP_FAILED",
+                str(e),
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
+
+        try:
+            v1.delete_namespaced_pod(pod_name, ns)
+            rollback["podDeleted"] = True
+        except client.exceptions.ApiException as e:
+            app.logger.exception("[DELETE POD] pod deletion failed")
+            return jsonify(infra_error(
+                "DELETE_POD",
+                "POD_DELETE_FAILED",
+                e.body,
+                rollback=rollback,
+                pod_name=pod_name,
+                **k8s_error_fields(e),
+            )), 500
+        except Exception as e:
+            app.logger.exception("[DELETE POD] pod deletion failed")
+            return jsonify(infra_error(
+                "DELETE_POD",
+                "POD_DELETE_FAILED",
+                str(e),
+                rollback=rollback,
+                pod_name=pod_name,
+            )), 500
         app.logger.info(f"[DELETE POD] pod deleted successfully: {pod_name}")
 
         return jsonify({"status": "deleted"})
 
     except Exception as e:
         app.logger.exception("[DELETE POD] deletion failed")
-        return jsonify({"error": str(e)}), 500
+        return jsonify(infra_error(
+            "DELETE_POD",
+            "DELETE_POD_FAILED",
+            str(e),
+            rollback=rollback,
+            pod_name=pod_name,
+        )), 500
 
 def _migrate_internal(data):
 

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -17,6 +17,8 @@ load_dotenv()
 import base64
 import crypt
 
+from error import infra_error, k8s_error_fields
+
 from utils import (
     get_db_connection, is_pod_ready, get_existing_pod, generate_pod_name, delete_pod_util,
     LockedFile,get_node_gpu_score,
@@ -126,25 +128,6 @@ def load_k8s():
         k8s_config.load_incluster_config()
     except:
         k8s_config.load_kube_config()
-
-
-def infra_error(step, error, detail, rollback=None, **extra):
-    body = {
-        "step": step,
-        "error": error,
-        "detail": detail,
-        "rollback": rollback or {},
-    }
-    body.update({key: value for key, value in extra.items() if value is not None})
-    return body
-
-
-def k8s_error_fields(exc):
-    return {
-        "k8s_status": exc.status,
-        "k8s_reason": exc.reason,
-        "k8s_body": exc.body,
-    }
 
 
 def wait_for_pod_deleted(v1, pod_name, namespace, timeout_sec=60):

--- a/config-server/test.py
+++ b/config-server/test.py
@@ -330,9 +330,10 @@ def select_best_node_from_prometheus(node_list):
     for node in node_list:
         query = f"""
         (
-          (sum(k8s_namespace_pod_count_total{{hostname="{node}"}}) or vector(0)) +
-          (count(gpu_process_memory_used_bytes{{hostname="{node}"}}) or vector(0))
-        ) / (count by (gpu_uuid) (gpu_temperature_celsius{{hostname="{node}"}}) > 0 or vector(1))
+          (avg(DCGM_FI_DEV_GPU_UTIL{{Hostname="{node}"}}) or vector(0)) +
+          ((avg(DCGM_FI_DEV_FB_USED{{Hostname="{node}"}}) or vector(0)) / 1024) +
+          ((avg(DCGM_FI_DEV_GPU_TEMP{{Hostname="{node}"}}) or vector(0)) / 100)
+        )
         """
         try:
             response = requests.get(f"{PROM_URL}/api/v1/query", params={"query": query}, timeout=2)
@@ -545,4 +546,3 @@ app.register_blueprint(accounts_bp, url_prefix="/accounts")
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8000, debug=True)
-

--- a/config-server/utils.py
+++ b/config-server/utils.py
@@ -711,11 +711,10 @@ def get_node_gpu_score(node: str, prom_url: str, timeout: float) -> float:
 
     query = f"""
     (
-      (sum(k8s_namespace_pod_count_total{{hostname="{node}"}}) or vector(0)) +
-      (count(gpu_process_memory_used_bytes{{hostname="{node}"}}) or vector(0))
+      (avg(DCGM_FI_DEV_GPU_UTIL{{Hostname="{node}"}}) or vector(0)) +
+      ((avg(DCGM_FI_DEV_FB_USED{{Hostname="{node}"}}) or vector(0)) / 1024) +
+      ((avg(DCGM_FI_DEV_GPU_TEMP{{Hostname="{node}"}}) or vector(0)) / 100)
     )
-    /
-    (count by (gpu_uuid) (gpu_temperature_celsius{{hostname="{node}"}}) > 0 or vector(1))
     """
 
     try:
@@ -755,9 +754,10 @@ def select_best_node_from_prometheus(node_list: List[str], prom_url: str, timeou
     for node in node_list:
         query = f"""
         (
-          (sum(k8s_namespace_pod_count_total{{hostname="{node}"}}) or vector(0)) +
-          (count(gpu_process_memory_used_bytes{{hostname="{node}"}}) or vector(0))
-        ) / (count by (gpu_uuid) (gpu_temperature_celsius{{hostname="{node}"}}) > 0 or vector(1))
+          (avg(DCGM_FI_DEV_GPU_UTIL{{Hostname="{node}"}}) or vector(0)) +
+          ((avg(DCGM_FI_DEV_FB_USED{{Hostname="{node}"}}) or vector(0)) / 1024) +
+          ((avg(DCGM_FI_DEV_GPU_TEMP{{Hostname="{node}"}}) or vector(0)) / 100)
+        )
         """
         try:
             app.logger.debug(f"Querying Prometheus for node {node}")

--- a/config-server/utils.py
+++ b/config-server/utils.py
@@ -228,6 +228,7 @@ def delete_nodeport_services(pod_name: str, namespace: str):
             )
     except Exception as e:
         app.logger.exception(f"[SERVICE DELETE] failed for pod {pod_name}: {e}")
+        raise
 
 
 # ============================


### PR DESCRIPTION
# 관련 이슈

- Closes #74

---

# Summary
1.  infra API 오류 응답을 구조화하여 admin_be가 실패 단계와 원인을 명확하게 해석할 수 있도록 개선
2. GPU 할당 시 prometheus query 문 수정 (그러다가 프로메테우스 gpu metric 수집 노드 복구도 했음)
3. delete-pod 삭제 완료 여부 Kubernetes Watch 도입
    - Kubernetes Watch : 리소스/pod 변경 이벤트 감지하는 쿠버네티스 API 

주요 변경 사항

- `/create-pod`, `/delete-pod`, `/pvc` 오류 응답을 `step / error / detail / progress` 기반으로 통일
- Kubernetes API 오류의 원본 정보(`status`, `reason`, `body`)를 응답에 포함
- `/delete-pod` 삭제 완료 여부를 Kubernetes Watch 기반으로 확인
- 이미 삭제된 Pod는 멱등(Idempotent) 성공 처리
- GPU 노드 선택 시 Prometheus DCGM Metric 사용

---

# 배경

기존에는 infra API별 오류 응답 형식이 일관되지 않아 admin_be에서 실패 원인과 위치를 정확하게 파악하기 어렵다.
-> 목표: admin이 에러를 명확히 보는 것으로 생각
-> approve 시, pvc/pod 생성 등이 명확히 해줘야 함.
 
<img width="598" height="515" alt="image" src="https://github.com/user-attachments/assets/bc049b35-ccc5-4248-878f-1a15047279fd" />

## 기존 문제

- `/pvc` 배치 처리 중 일부 항목이 실패해도 HTTP 200이 반환되는 경우가 있었음
- `/create-pod`, `/delete-pod` 오류 응답이 단순 문자열 수준이어서 실패 단계 구분이 어려웠음
- Kubernetes API 오류 원본 정보가 충분히 전달되지 않았음
- `/delete-pod`는 삭제 요청 성공과 실제 Pod 삭제 완료를 구분하지 못했음  
    - pod 상태를 모르고 계속 생성하면 문제가...?

## 원인

- infra API별 오류 응답 포맷이 통일되지 않았음
- Kubernetes ApiException이 단계별로 구분되지 않고 일반 예외로 처리되는 경로가 있었음
- `delete_namespaced_pod()`가 비동기 삭제 요청이라는 점이 응답에 반영되지 않았음

---

# 변경 사항

## 1. 공통 오류 응답 포맷 추가

`config-server/error.py`를 추가하고 공통 오류 응답 Helper를 분리

### 기본 오류 응답

```json
{
  "step": "CREATE_POD",
  "error": "POD_CREATE_FAILED",
  "detail": "...",
  "progress": {},
  "k8s_status": 422,
  "k8s_reason": "Unprocessable Entity",
  "k8s_body": "..."
}
```

### 추가 Helper

```python
infra_error(step, error, detail, progress, **extra)
k8s_error_fields(exc)
```

## 2. /create-pod 오류 응답 구조화
응답을 구조화 해서 be에서 신청 수락 후, 중간 지점 실패 시 바로 pod 삭제 돌입 (트랜잭션 보장)

실패 지점을 단계별로 구분하도록 변경

| Step | Error |
|--------|--------|
| VALIDATE_REQUEST | INVALID_CREATE_POD_REQUEST |
| FETCH_USER_CONFIG | USER_CONFIG_FETCH_FAILED |
| CHECK_EXISTING_POD | POD_CHECK_FAILED |
| BUILD_POD_SPEC | POD_SPEC_BUILD_FAILED |
| CREATE_POD | POD_CREATE_FAILED |
| WAIT_POD_READY | POD_READY_TIMEOUT |
| CREATE_NODEPORT_SERVICE | NODEPORT_SERVICE_CREATE_FAILED |

Kubernetes API 오류 발생 시 `k8s_status`, `k8s_reason`, `k8s_body`를 함께 반환합니다.

## 3. /delete-pod 삭제 완료 확인 개선

삭제 과정을 다음 단계로 분리했습니다.

1. NodePort Service 삭제
2. NodePort Allocation 해제
3. Pod 삭제 요청
5. Kubernetes Watch 기반 실제 삭제 완료 확인

### 이미 삭제된 Pod

```json
{
  "status": "deleted",
  "pod_name": "ailab-user-abc",
  "already_absent": true,
  "progress": {
    "servicesDeleted": true,
    "nodeportsReleased": true,
    "podDeleteRequested": false,
    "podDeleted": true
  }
}
```

### 삭제 Timeout

```text
DELETE_POD / POD_DELETE_TIMEOUT
```

삭제 요청 후 60초 내에 `DELETED` 이벤트가 확인되지 않으면 반환됩니다.

## 4. /pvc Batch 오류 응답 구조화

배치 결과 중 하나라도 실패하면 HTTP 500을 반환하도록 변경했습니다.

### 실패 응답 예시

```json
{
  "results": [
    {
      "step": "CREATE_PVC",
      "error": "PVC_CREATE_FAILED",
      "detail": "...",
      "progress": {},
      "name": "abc",
      "type": "user",
      "k8s_status": 422,
      "k8s_reason": "Unprocessable Entity",
      "k8s_body": "..."
    }
  ]
}
```

### HTTP Status 정책

| 상황 | Status |
|--------|--------|
| 요청 자체가 잘못됨 | 400 |
| 배치 결과 중 실패 존재 | 500 |
| 전체 성공 | 200 |

## 5. DCGM Metric 기준 반영

GPU 노드 선택 시 사용하는 Metric을 실제 dcgm-exporter 기준으로 변경했습니다.

### 기존

- gpu_temperature_celsius
- gpu_process_memory_used_bytes
- hostname

### 변경

- DCGM_FI_DEV_GPU_UTIL
- DCGM_FI_DEV_FB_USED
- DCGM_FI_DEV_GPU_TEMP
- Hostname

---

# admin_be 수정 사항

admin_be는 infra 오류 처리 시 HTTP Status뿐 아니라 응답 Body도 함께 해석해야 합니다.

## 주요 대응 사항

### 1. 공통 오류 필드 파싱

- step
- error
- detail
- progress
- k8s_status
- k8s_reason
- k8s_body

### 2. /pvc 처리 수정

`results[]` 내부의 `error` 존재 여부를 확인해야 합니다.

### 3. delete-pod 특수 케이스 처리

- `already_absent=true` → 정상 삭제 처리 가능
- `POD_DELETE_TIMEOUT` → 별도 예외 처리 가능

### 참고

이번 변경에는 다음 내용은 포함되지 않습니다.

- Audit DB 스키마 변경
- Audit 로그 저장 방식 변경
- Retry 정책 변경
- DB 마이그레이션

---

# 테스트

## 검증 완료

- [x] `python3 -m py_compile config-server/error.py config-server/main.py config-server/utils.py config-server/test.py`
- [x] `/create-pod` Validation 실패 응답 확인
- [x] `/delete-pod` 404 멱등 성공 응답 확인
- [x] `/delete-pod` Watch Timeout 응답 확인
- [x] `/pvc` 실패 응답에 `progress`, `k8s_*` 필드 포함 확인
- [x] DCGM Metric 기반 노드 선택 Mock 검증

## 추가 확인 필요

- [ ] 실제 Kubernetes 환경에서 Watch 기반 삭제 완료 확인
- [ ] admin_be의 `step/error/detail/progress/k8s_*` 매핑 확인
- [ ] `/pvc` 일부 실패 시 admin_be 동작 확인

---

# 의논 사항

### 1. delete-pod Timeout 처리

`POD_DELETE_TIMEOUT` 발생 시 admin_be가 단순 실패 처리할지, 이후 상태 재조회 로직을 둘지 검토가 필요?