### PR TITLE
fix(config-server): krb5 keytab Secret 생성 전 load_k8s() 호출 (계정 생성 502)

### DIFF
--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1630,6 +1630,7 @@ def _create_krb5_principal_and_secret(username: str) -> None:
             keytab_bytes = f.read()
     finally:
         os.unlink(keytab_path)
+    load_k8s()  # 계정 CRUD 경로는 load_k8s()를 안 거쳐 k8s 기본값 localhost:80으로 붙음 → in-cluster config 보장
     v1 = client.CoreV1Api()
     secret = client.V1Secret(
         metadata=client.V1ObjectMeta(
@@ -1646,6 +1647,7 @@ def _delete_krb5_principal_and_secret(username: str) -> None:
         _kadmin_run(f"delprinc -force {username}@{realm}")
     except Exception as e:
         app.logger.warning(f"[KRB5] principal 삭제 실패 (무시): {e}")
+    load_k8s()  # 계정 CRUD 경로 in-cluster config 보장 (create와 동일 구멍)
     v1 = client.CoreV1Api()
     try:
         v1.delete_namespaced_secret(


### PR DESCRIPTION
## 증상
운영 FE에서 신청 승인 시 502 — `사용자 계정 생성에 실패했습니다`.
```
approveRequest → PUT /accounts/users → 502
```

## 원인 (실측 로그)
config-server 계정 생성 경로에서 kadmin principal은 생성되지만, keytab을 k8s Secret으로 저장하는 단계에서 실패.
```
[ACCOUNTS] KRB5 principal creation failed for user=..., rolling back
create_namespaced_secret /api/v1/namespaces/ailab-infra/secrets
HTTPConnection(host='localhost', port=80) ... Connection refused
```
`_create_krb5_principal_and_secret`가 `client.CoreV1Api()`를 쓰기 전 `load_k8s()`(in-cluster config 로딩)를 호출하지 않는다. `load_k8s()`는 파드 핸들러에만 있고 계정 CRUD 경로엔 없어서, k8s 클라이언트가 기본값 `localhost:80`으로 붙는다. approveRequest는 계정 생성이 첫 k8s 작업이라(파드 생성은 그 뒤) 이 지점에서 항상 깨진다.

## 수정
`_create_krb5_principal_and_secret` / `_delete_krb5_principal_and_secret`에서 `CoreV1Api` 사용 직전 `load_k8s()`(idempotent) 호출. 2줄 추가.

## 검증
- `python -m py_compile` 통과.
- 병합·재배포 후 신청 승인 → 계정(uid≥20000) + keytab Secret 생성 → 파드 생성까지 확인 필요.

## 참고
KRB5는 #82로 활성화된 기능이라 끄는 우회 대신 근본 수정. 재배포 시 이전 helm orphan(`krb5-conf`) 이슈는 이미 해소되어 #82가 정상 배포된 상태.

🤖 Generated with [Claude Code](https://claude.com/claude-code)