### PR TITLE
fix(config-server): Role에 secrets 권한 추가 (krb5 keytab 403 → 계정 생성 502)

### DIFF
--- a/config-server/Chart/templates/rbac.yaml
+++ b/config-server/Chart/templates/rbac.yaml
@@ -12,6 +12,10 @@ rules:
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list", "create", "delete", "patch", "update"]
+# krb5 keytab Secret(krb5-keytab-<user>) 생성/조회/삭제 — #82 KRB5 계정 연동
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## 증상
#83(load_k8s) 배포 후에도 신청 승인 502 지속 — 계정 생성 실패.

## 원인 (실측 로그)
in-cluster config는 해결됐고(#83), 이제 k8s API 도달 후 **RBAC 403**:
```
create_namespaced_secret /api/v1/namespaces/ailab-infra/secrets
secrets is forbidden: User "system:serviceaccount:ailab-infra:config-server"
cannot create resource "secrets" in the namespace "ailab-infra"  code:403
```
`config-server-role`이 pods/services/pvc엔 권한이 있으나 **secrets 규칙이 없음**. #82 KRB5 연동이 `krb5-keytab-<user>` Secret을 create/get/delete 하는데 Role이 이를 허용하지 않아 계정 생성이 롤백되고 admin_be가 502.

## 수정
`config-server-role`에 secrets 규칙 추가:
```yaml
- apiGroups: [""]
  resources: ["secrets"]
  verbs: ["get", "list", "create", "delete"]
```

## 검증
- 머지·재배포(helm이 Role 갱신) 후 신청 승인 → 계정(uid≥20000)+keytab Secret+파드 생성까지 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)