### PR TITLE
fix(config-server): openssh-client 설치 (krb5 farm keytab SSH → 파드 생성 실패)

### DIFF
--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     krb5-user \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## 증상
#83·#84 이후 계정 생성은 통과했으나, 신청 승인의 **파드 생성** 단계에서 실패 — admin_be `Pod 생성 API 요청에 실패했습니다`.

## 원인 (실측 로그)
```
[POD SPEC] failed after nodeport allocation; releasing rows pod=ailab-testdongmin-...
[KRB5] farm 정리 실패 (무시): farm1 — [Errno 2] No such file or directory: 'ssh'
(farm1~9 동일)
```
`KRB5_REALM`이 켜져 `build_pod_spec`가 `_deploy_krb5_to_farm` → `_farm_ssh` → `subprocess.run(["ssh", ...])`를 호출하는데, config-server 이미지에 **openssh-client가 없어** `FileNotFoundError: 'ssh'`. 파드 스펙 빌드가 실패하고 nodeport를 롤백. (#82 Dockerfile은 krb5-user만 설치)

## 수정
Dockerfile apt install에 `openssh-client` 추가.

## 검증
- 머지·재배포 후 신청 승인 → 계정 → keytab Secret → **farm keytab SSH 배포** → 파드 Running 확인 필요.
- ⚠️ 다음 레이어: farm 노드의 forced-command 서비스계정/스크립트와 `FARM_NODES_JSON`이 준비돼 있어야 `_farm_ssh`가 실제로 성공. 없으면 SSH 인증/연결 단계에서 또 막힘(별도 farm 셋업).

🤖 Generated with [Claude Code](https://claude.com/claude-code)