### PR TITLE
fix(config-server): POD SPEC 실패 예외 로깅(exc_info) — farm 배포 실패 원인 가시화

### DIFF
--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1130,8 +1130,9 @@ def build_pod_spec(
         return spec, allocated_ports
     except Exception as e:
         app.logger.warning(
-            "[POD SPEC] failed after nodeport allocation; releasing rows pod=%s",
-            pod_name,
+            "[POD SPEC] failed after nodeport allocation; releasing rows pod=%s — %s",
+            pod_name, e,
+            exc_info=True,
         )
         rollback = {"nodeportsReleased": False}
         try:


### PR DESCRIPTION
## 배경
신청 승인의 파드 생성 단계가 실패하는데, `build_pod_spec`의 except가 `exc_info` 없이 warning만 남겨 **실제 예외가 로그에서 완전히 사라짐**. admin_be는 502/파드 실패만 보이고 config-server 로그로 근본 원인을 못 짚음.

현재 정황: farm SSH 자체는 동작(`[KRB5] farm 정리 완료 ...`)하나 `_deploy_krb5_to_farm`(keytab 배포+TGT 확인)에서 예외가 나 파드 생성이 롤백됨. 그 예외 내용이 필요.

## 수정
```python
except Exception as e:
    app.logger.warning(
        "[POD SPEC] failed after nodeport allocation; releasing rows pod=%s — %s",
        pod_name, e, exc_info=True,
    )
```
예외 메시지 + 전체 트레이스백 로깅.

## 검증
- `py_compile` 통과.
- 재배포 후 승인 재시도 시 farm 배포 실패의 실제 원인(TGT/KDC/스크립트)이 로그에 노출됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)