### PR TITLE
fix(config-server): 빈 keytab 저장 버그 (kinit Unsupported key table format)

### DIFF
--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1625,12 +1625,19 @@ def _create_krb5_principal_and_secret(username: str) -> None:
     _kadmin_run(f"addprinc -randkey {principal}")
     with tempfile.NamedTemporaryFile(suffix=".keytab", delete=False) as f:
         keytab_path = f.name
+    # kadmin ktadd는 대상 경로가 이미 존재하는 0바이트 파일이면 keytab으로 열지 못해
+    # "Unsupported key table format" 로 실패한다(단 kadmin exit는 0이라 조용히 빈 keytab이 됨).
+    # 미리 지워 kadmin이 새 keytab을 생성하도록 한다.
+    os.unlink(keytab_path)
     try:
         _kadmin_run(f"ktadd -k {keytab_path} {principal}")
         with open(keytab_path, "rb") as f:
             keytab_bytes = f.read()
     finally:
-        os.unlink(keytab_path)
+        if os.path.exists(keytab_path):
+            os.unlink(keytab_path)
+    if not keytab_bytes:
+        raise RuntimeError(f"ktadd로 생성된 keytab이 비어 있음: {principal}")
     load_k8s()  # 계정 CRUD 경로는 load_k8s()를 안 거쳐 k8s 기본값 localhost:80으로 붙음 → in-cluster config 보장
     v1 = client.CoreV1Api()
     secret = client.V1Secret(


### PR DESCRIPTION
## 증상
신청 승인의 파드 생성 단계에서 farm keytab 배포 실패:
```
kinit: Unsupported key table format version number while getting initial credentials
```

## 근본 원인 (config-server 파드에서 실증)
`_create_krb5_principal_and_secret`가 `NamedTemporaryFile`로 keytab 경로를 **0바이트 파일로 미리 생성**한 뒤 `kadmin ktadd -k <그 파일>`을 호출. kadmin ktadd는 이미 존재하는 0바이트 파일을 keytab으로 열지 못해 실패하는데, **kadmin의 exit code는 0**이라 config-server는 빈 keytab을 Secret에 저장. 그 결과:
- k8s Secret `krb5-keytab-<user>`의 값이 **빈 문자열**
- farm 노드가 빈 keytab을 받아 `kinit`이 동일 에러로 실패 → 파드 생성 롤백 → admin_be 502/파드 실패

실증(테스트 계정 krbdbg1, config-server 파드 내 kadmin):
```
A) mktemp로 만든 0바이트 파일에 ktadd → "Unsupported key table format" → 0바이트
B) 존재하지 않는 경로에 ktadd       → "Entry ... added to keytab"      → 136바이트(정상)
```

## 수정
- ktadd 호출 전 임시파일을 `os.unlink`하여 kadmin이 **새 keytab을 생성**하게 함.
- `finally`는 존재 확인 후 삭제.
- keytab이 비면 `RuntimeError`로 조용한 실패 차단(kadmin이 실패해도 exit 0인 케이스 방어).

## 검증
- `py_compile` 통과.
- 재배포 후 계정 생성 → Secret keytab 비어있지 않음(≈136B) 확인 → 승인 E2E(파드 Running)까지 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)