### PR TITLE
fix(config-server): 유저 파드에서 image-store PVC 마운트 제거 (mount access denied)

### DIFF
--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1006,9 +1006,11 @@ def build_pod_spec(
                 })
 
         # NFS user-share 전체를 /home에 마운트 — 유저 격리는 chmod 700으로 처리
+        # image-store PVC(pvc-image-store)는 제거 — 해당 PV의 NFS subdir가
+        # 미치환 템플릿(user-share/${pvc.annotations.nfs.io/username})이라 모든 유저 파드가
+        # mount access denied로 Ready 실패. MVP는 image-store 불필요.
         volume_mounts = [
             {"name": "nfs-home",    "mountPath": "/home",        "readOnly": False},
-            {"name": "image-store", "mountPath": "/image-store", "readOnly": False},
         ]
         volumes = [
             {
@@ -1018,10 +1020,6 @@ def build_pod_spec(
                     "path":     app.config["NFS_USER_SHARE_PATH"],
                     "readOnly": False,
                 }
-            },
-            {
-                "name": "image-store",
-                "persistentVolumeClaim": {"claimName": "pvc-image-store"}
             },
         ]
 


### PR DESCRIPTION
## 증상
신청 승인 시 파드는 생성되나 Ready 실패 → 롤백 → 502.
```
FailedMount pvc-image-store(pvc-e2edde72): access denied by server while mounting
  192.168.2.30:/volume1/share/user-share/${pvc.annotations.nfs.io/username}
```

## 원인
config-server가 모든 유저 파드에 `pvc-image-store`를 마운트하는데, 그 backing PV(StorageClass `nfs-nas-v3-expandable-v2`)의 `subdir`가 **치환 안 된 템플릿** `user-share/${pvc.annotations.nfs.io/username}` 그대로다(PVC에 `nfs.io/username` annotation 미설정). NFS 서버가 그 리터럴 경로 마운트를 거부 → 파드마다 Ready 실패.

## 수정
유저 파드 스펙에서 `image-store` volume/volumeMount 제거. 홈은 `nfs-home` 직접 NFS 마운트만 사용(PVC 폐기 방침과 일치). image-store(컨테이너 저장) 기능은 MVP 범위 밖.

## 검증
- `py_compile` 통과.
- 재배포 후 승인 시 이 마운트 실패 소거 확인. (별건: `nfs-home` krb5 "Key has expired" 잔여 이슈는 NFS krb5 레이어로 별도)

🤖 Generated with [Claude Code](https://claude.com/claude-code)