### PR TITLE
fix: farm SSH 타임아웃 시 1회 재시도

### DIFF
--- a/config-server/Chart/values.yaml
+++ b/config-server/Chart/values.yaml
@@ -11,11 +11,11 @@ service:
 
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 200m
+    cpu: 250m
     memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
 
 nfs:
   server: ""

--- a/config-server/main.py
+++ b/config-server/main.py
@@ -1708,18 +1708,30 @@ def _get_farm_node_info(node_name: str) -> dict:
 
 def _farm_ssh(host: str, port: str, remote_command: str, stdin_data: str = "") -> str:
     """전용 서비스 계정으로 접속한다. 계정 쪽에 forced-command가 걸려 있어
-    remote_command는 그대로 실행되지 않고 원격 스크립트가 참고하는 값으로만 쓰인다."""
-    result = subprocess.run(
-        ["ssh",
-         "-i", app.config["FARM_SSH_KEY_PATH"],
-         "-o", "StrictHostKeyChecking=no",
-         "-o", "BatchMode=yes",
-         "-p", str(port),
-         f"{app.config['FARM_SSH_USER']}@{host}",
-         remote_command],
-        input=stdin_data,
-        capture_output=True, text=True, timeout=30,
-    )
+    remote_command는 그대로 실행되지 않고 원격 스크립트가 참고하는 값으로만 쓰인다.
+    간헐적으로 최초 접속만 타임아웃되고 곧바로 재시도하면 성공하는 현상이 있어 타임아웃 시 1회 재시도한다."""
+    cmd = ["ssh",
+           "-i", app.config["FARM_SSH_KEY_PATH"],
+           "-o", "StrictHostKeyChecking=no",
+           "-o", "BatchMode=yes",
+           "-p", str(port),
+           f"{app.config['FARM_SSH_USER']}@{host}",
+           remote_command]
+
+    result = None
+    last_error = None
+    for attempt in range(2):
+        try:
+            result = subprocess.run(
+                cmd, input=stdin_data, capture_output=True, text=True, timeout=30,
+            )
+            break
+        except subprocess.TimeoutExpired as e:
+            last_error = e
+            app.logger.warning(f"[FARM SSH] {host}:{port} 타임아웃, 재시도 {attempt+1}/2")
+    if result is None:
+        raise last_error
+
     if result.returncode != 0:
         raise RuntimeError(f"farm SSH 실패 ({host}:{port}): {result.stderr.strip()}")
     return result.stdout


### PR DESCRIPTION
## Summary
- `test0711` 실계정 승인 테스트 중 발견된 pod 생성 실패 3건을 각각 원인 규명 후 수정
  1. `imagePullPolicy: Never` → `IfNotPresent`: 노드에 이미지 미리 없으면 무조건 `ErrImageNeverPull`로 실패하던 문제
  2. pod ready 대기 로직이 "이미지 pull 진행 중"과 "진짜 실패"(`ImagePullBackOff`/`CrashLoopBackOff`)를 구분 못 하고 60초 뒤 무조건 롤백하던 문제 → 진짜 실패는 즉시, 진행 중이면 최대 600초까지 대기하도록 수정
  3. farm 노드로의 krb5 배포/정리 SSH가 간헐적으로 30초 타임아웃 나던 문제 → config-server pod의 CPU limit(200m)이 너무 낮아 SSH 핸드셰이크 중 cgroup에 스로틀링되는 것이 근본 원인으로 확인(11분 가동에 throttle 346회/20.7초). CPU/메모리 limit 상향 + SSH 타임아웃 시 1회 재시도 추가